### PR TITLE
feat(appellate): Add RECAP links and the RECAP button.

### DIFF
--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -106,6 +106,30 @@ AppellateDelegate.prototype.handleAcmsDocket = async function () {
     }
   }
 
+  const insertRecapButton = () => {
+    // Query the first table with case data and insert the RECAP actions button
+    let caseInformationTable = document.querySelector('table.case-information');
+    // Get a reference to the parent node
+    const parentDiv = caseInformationTable.parentNode;
+    const existingActionButton = document.getElementById('recap-action-button');
+    if (!existingActionButton) {
+      let button = recapActionsButton(this.court, this.pacer_case_id, false);
+      parentDiv.insertBefore(button, caseInformationTable);
+    }
+
+    this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
+      if (result.count === 0) {
+        console.warn('RECAP: Zero results found for docket lookup.');
+      } else if (result.count > 1) {
+        console.error(`RECAP: More than one result found for docket lookup. Found ${result.count}`);
+      } else {
+        addAlertButtonInRecapAction(this.court, this.pacer_case_id);
+        let cl_id = getClIdFromAbsoluteURL(result.results[0].absolute_url);
+        addSearchDocketInRecapAction(cl_id);
+      }
+    });
+  };
+
   const attachLinkToDocs = async () => {
     // Get the docket info from the sessionStorage obj
     const caseSummary = JSON.parse(sessionStorage.caseSummary);
@@ -208,6 +232,7 @@ AppellateDelegate.prototype.handleAcmsDocket = async function () {
           if ('caseSummary' in sessionStorage) {
 	    processDocket();
       attachLinkToDocs();
+      insertRecapButton();
             observer.disconnect();
           } else {
             console.log('We observed a <footer> being added, but no '+

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -27,8 +27,6 @@ AppellateDelegate.prototype.dispatchPageHandler = function () {
     } else if (this.path.match(/^\/[0-9\-]+$/)) {
       // this.handleDocketDisplayPage();
       this.handleAcmsDocket();
-      // this.attachRecapLinksToEligibleDocs();
-      console.log('We would attach links based on the acms JSON.');
     }
     /* Fall through to CM/ECF, probably not what should happen */
   }
@@ -108,6 +106,61 @@ AppellateDelegate.prototype.handleAcmsDocket = async function () {
     }
   }
 
+  const attachLinkToDocs = async () => {
+    // Get the docket info from the sessionStorage obj
+    const caseSummary = JSON.parse(sessionStorage.caseSummary);
+    const docketEntries = caseSummary.docketInfo.docketEntries;
+
+    // Get all the entry links on the page. We use the "entry-link"
+    // class as a selector because we observed that all non-restricted
+    // entries consistently use this class.
+    this.links = document.body.querySelectorAll('.entry-link');
+    if (!links.length) {
+      return;
+    }
+
+    // Go through the array of links and collect the doc IDs of
+    // the entries that are not restricted.
+    let docIds = [];
+    for (link of this.links) {
+      const docketEntryText = link.innerHTML.trim();
+      const docketEntryData = docketEntries.find((entry) => entry.entryNumber == parseInt(docketEntryText));
+
+      // Embed the pacer_doc_id as a data attribute within the anchor tag
+      // to facilitate subsequent retrieval based on this identifier.
+      link.dataset.pacerDocId = docketEntryData.docketEntryId;
+
+      // add the id to the array of doc ids
+      docIds.push(docketEntryData.docketEntryId);
+    }
+
+    // Ask the server whether any of these documents are available from RECAP.
+    this.recap.getAvailabilityForDocuments(docIds, this.court, (response) => {
+      for (result of response.results) {
+        let doc_id = result.pacer_doc_id;
+        // Query the docket entry link using the data attribute attached previously
+        let anchor = document.querySelector(`[data-pacer-doc-id="${doc_id}"]`);
+        // Create the RECAP icon
+        let href = `https://storage.courtlistener.com/${result.filepath_local}`;
+        let recap_link = $('<a/>', {
+          title: 'Available for free from the RECAP Archive.',
+          href: href,
+        });
+        recap_link.append(
+          $('<img/>').attr({
+            src: chrome.extension.getURL('assets/images/icon-16.png'),
+          })
+        );
+        let recap_div = $('<div>', {
+          class: 'recap-inline-appellate',
+        });
+        recap_div.append(recap_link);
+        // Insert the RECAP icon next to the docket entry link
+        recap_div.insertAfter(anchor);
+      }
+    });
+  };
+
   // The DOM begins as:
   //   <html>
   //     <body>
@@ -154,6 +207,7 @@ AppellateDelegate.prototype.handleAcmsDocket = async function () {
 	  // HistoryContact Us
           if ('caseSummary' in sessionStorage) {
 	    processDocket();
+      attachLinkToDocs();
             observer.disconnect();
           } else {
             console.log('We observed a <footer> being added, but no '+

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -246,20 +246,29 @@ AppellateDelegate.prototype.handleAcmsDocket = async function () {
       }
     }
   };
-  
-  const body = document.querySelector('body');
 
-  // xxx: when this was AppelateDelegate.prototype.footerObserver,
-  // then reference to this.footerObserver failed, complaining it was
-  // not an object.
-  // ???
-  // So just use regular function I guess.
-  const observer = new MutationObserver(footerObserver);
-  observer.observe(body, { subtree: true, childList: true });
+  const footer = document.querySelector('footer')
+  // Checks whether the footer is rendered or not, indicating that the page
+  // has fully loaded. Once confirmed, proceed with reloading the RECAP icons.
+  // This check is particularly useful when users click the 'Refresh RECAP links'
+  // option in the RECAP button, because the page is not reloaded and there are no
+  // changes being made to the DOM.
+  if (footer){
+    attachLinkToDocs();
+  } else {
+    const body = document.querySelector('body');
 
-  // const observer2 = new MutationObserver(loggingMutationObserver);
-  // observer2.observe(body, { subtree: true, childList: true });
+    // xxx: when this was AppelateDelegate.prototype.footerObserver,
+    // then reference to this.footerObserver failed, complaining it was
+    // not an object.
+    // ???
+    // So just use regular function I guess.
+    const observer = new MutationObserver(footerObserver);
+    observer.observe(body, { subtree: true, childList: true });
 
+    // const observer2 = new MutationObserver(loggingMutationObserver);
+    // observer2.observe(body, { subtree: true, childList: true });
+  }
 };
 
 AppellateDelegate.prototype.handleCaseSearchPage = () => {

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -182,6 +182,10 @@ AppellateDelegate.prototype.handleAcmsDocket = async function () {
         // Insert the RECAP icon next to the docket entry link
         recap_div.insertAfter(anchor);
       }
+      let spinner = document.getElementById('recap-button-spinner');
+      if (spinner) {
+        spinner.classList.add('recap-btn-spinner-hidden');
+      }
     });
   };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -92,8 +92,8 @@
     ]
   },
   "content_scripts": [{
-    "matches": ["*://*.uscourts.gov/*"],
-    "include_globs": ["*://ecf.*", "*://ecf-train.*", "*://pacer.*"],
+    "matches": ["*://*.uscourts.gov/*", "*://*.azurewebsites.us/*"],
+    "include_globs": ["*://ecf.*", "*://ecf-train.*", "*://pacer.*", "*://*-showdoc.*"],
     "css": [
       "assets/css/style.css",
       "assets/css/font-awesome.css"


### PR DESCRIPTION
This pull request introduces new methods for inserting the recap icon next to docket entry links whenever the corresponding document is accessible in the Recap archive and the RECAP button. The new helper functions are incorporated into the `handleAcmsDocket` method to use the existing `mutationObserver` and avoid repetition.